### PR TITLE
ci: Trigger Release workflow from semantic-release via workflow_dispatch

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -12,6 +12,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   release:
@@ -35,6 +36,7 @@ jobs:
             @semantic-release/github@10 \
             @semantic-release/commit-analyzer@13 \
             @semantic-release/release-notes-generator@14 \
+            @semantic-release/exec@7 \
             conventional-changelog-conventionalcommits@8
 
       - name: Run semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,13 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    "@semantic-release/github",
+    [
+      "@semantic-release/exec",
+      {
+        "successCmd": "gh workflow run Release --ref ${nextRelease.gitTag}"
+      }
+    ]
   ],
   "preset": "conventionalcommits",
   "tagFormat": "${version}",


### PR DESCRIPTION
## Problem

When `semantic-release` publishes a release using the workflow's `GITHUB_TOKEN`, the resulting `release: published` event is **silently suppressed** by GitHub Actions and does not trigger downstream workflows. This is a [documented anti-cascade safety rule](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run.

**Effect on this repo:** the `Release` workflow (which runs goreleaser → cross-platform binaries + Docker push to ghcr.io) has *never* auto-fired after a release. Every release since (and including) `0.4.3` has required someone to manually click "Run workflow" on the tag. `0.4.4` (the security/Go-1.26 release) was no exception — the binaries had to be attached manually.

Evidence:

```
$ gh run list --workflow Release --limit 8
0.4.4  workflow_dispatch  ← manual
0.4.3  workflow_dispatch  ← manual
... (no `release` events anywhere)
```

## Fix

Wire `semantic-release` to explicitly invoke the `Release` workflow via `gh workflow run` after a successful publish, using the `@semantic-release/exec` plugin. `workflow_dispatch` events **are** allowed to cascade even when caused by `GITHUB_TOKEN` (per the docs quote above), so this works without any extra secrets or PATs.

### `.releaserc.json`

Adds the `@semantic-release/exec` plugin at the end of the chain:

```jsonc
[
  "@semantic-release/exec",
  {
    "successCmd": "gh workflow run Release --ref ${nextRelease.gitTag}"
  }
]
```

`successCmd` runs only after a release is actually published — so this won't fire on no-op semantic-release runs (e.g., when there are no release-eligible commits).

### `.github/workflows/semantic-release.yaml`

- Adds `actions: write` to the workflow's permissions (required for `gh workflow run`).
- Adds `@semantic-release/exec@7` to the npm install line.

## Why not other approaches

- **PAT / GitHub App token for `semantic-release`:** would also work, but adds secret-management overhead. Not needed here.
- **Merge `Release` into `Semantic Release`:** loses the ability to manually re-run goreleaser independently for an existing tag.
- **Status quo (manual trigger):** what we've been doing. Easy to forget; a single missed manual step ships a release without binaries.

## Test plan

- [x] `.releaserc.json` is valid JSON
- [x] `semantic-release.yaml` is valid YAML
- [ ] After merge to develop and forward-merge to master, the next release should auto-trigger the `Release` workflow without manual intervention. Verifiable via `gh run list --workflow Release --limit 1` showing `release` or `workflow_dispatch` (from the exec plugin) instead of a manual one.